### PR TITLE
Update distmesh2d.R

### DIFF
--- a/R/distmesh2d.R
+++ b/R/distmesh2d.R
@@ -200,7 +200,7 @@ distmesh2d <- function(fd, fh, h0, bbox, p=NULL, pfix=array(0,dim=c(0,2)), ...,
     p = p + deltat*Ftot;
 
     #%7 excercise normal force at boundary: move overshoot points to nearest boundary point
-    d = fd(p);
+    d = fd(p, ...);
     ix= d > 0;                                                  # find points outside
     dgradx= (fd(cbind(p[ix, 1]+deps, p[ix, 2]),...) - d[ix])/deps;  # Numerical
     dgrady= (fd(cbind(p[ix, 1], p[ix, 2]+deps),...) - d[ix])/deps;  #    gradient


### PR DESCRIPTION
Line 203 has been changed from "d = fd(p);" to "d = fd(p, ...);". This is to be consistent with other calls to the function fd, which allow additional user parameters to be passed to the function. Previously, distmesh2d would crash at this line if fd required any additional parameters.